### PR TITLE
AccountsDb replication bootstrap code

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -12,7 +12,7 @@
         "@project-serum/serum": "^0.13.52",
         "@react-hook/debounce": "^4.0.0",
         "@sentry/react": "^6.9.0",
-        "@solana/spl-token-registry": "^0.2.195",
+        "@solana/spl-token-registry": "^0.2.199",
         "@solana/web3.js": "^1.21.0",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
@@ -3247,9 +3247,9 @@
       }
     },
     "node_modules/@solana/spl-token-registry": {
-      "version": "0.2.195",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token-registry/-/spl-token-registry-0.2.195.tgz",
-      "integrity": "sha512-AMEwVFSyiVaFU+zQQd7eWnNHAhbBr7UAEvAsQskSu06pYjlS94cSfMk96f0TLtHDzyHjvT6oI2H1FO75GhuDPQ==",
+      "version": "0.2.199",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-registry/-/spl-token-registry-0.2.199.tgz",
+      "integrity": "sha512-qBMZiDnagO3K1uQ+wFAyr62AeaH5oXT9oifZw6ae6X1OiXy+O59cK7Ad5gMRPaB/r2MFufM58zL6QAk9Ha3Hlw==",
       "dependencies": {
         "cross-fetch": "3.0.6"
       },
@@ -27471,9 +27471,9 @@
       }
     },
     "@solana/spl-token-registry": {
-      "version": "0.2.195",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token-registry/-/spl-token-registry-0.2.195.tgz",
-      "integrity": "sha512-AMEwVFSyiVaFU+zQQd7eWnNHAhbBr7UAEvAsQskSu06pYjlS94cSfMk96f0TLtHDzyHjvT6oI2H1FO75GhuDPQ==",
+      "version": "0.2.199",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-registry/-/spl-token-registry-0.2.199.tgz",
+      "integrity": "sha512-qBMZiDnagO3K1uQ+wFAyr62AeaH5oXT9oifZw6ae6X1OiXy+O59cK7Ad5gMRPaB/r2MFufM58zL6QAk9Ha3Hlw==",
       "requires": {
         "cross-fetch": "3.0.6"
       },

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -8,7 +8,7 @@
     "@project-serum/serum": "^0.13.52",
     "@react-hook/debounce": "^4.0.0",
     "@sentry/react": "^6.9.0",
-    "@solana/spl-token-registry": "^0.2.195",
+    "@solana/spl-token-registry": "^0.2.199",
     "@solana/web3.js": "^1.21.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",


### PR DESCRIPTION
#### Problem
This is the first installment of the implementation for accounts db replication.
#### Summary of Changes
The rpc-node changes from Steven's is cherry-picked which create the solana-rpc-node exectuable. With additional changes:
1. Taking the pub key of the peer node
2. Auto figuring out the latest snapshot's slot and hash
3. Code refactoring.
Fixes #
