### PR TITLE
Always use ed25519_dalek for the QUIC-TLS cert verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7848,6 +7848,7 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "dashmap",
+ "ed25519-dalek",
  "futures 0.3.30",
  "futures-util",
  "governor",

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 async-channel = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
+ed25519-dalek = { workspace = true }
 dashmap = { workspace = true }
 futures  = { workspace = true }
 futures-util = { workspace = true }

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -5,7 +5,9 @@ use {
         DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STREAMS_PER_MS,
     },
     crate::{
-        quic::{StreamerStats, MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
+        quic::{
+            StreamerStats, MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS, TLS_SIGVERIFY_SCHEMES,
+        },
         streamer::StakedNodes,
         tls_certificates::new_dummy_x509_certificate,
     },
@@ -29,27 +31,24 @@ use {
 };
 
 #[derive(Debug)]
-pub struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
+pub struct SkipServerVerification;
 
 impl SkipServerVerification {
     pub fn new() -> Arc<Self> {
-        Arc::new(Self(Arc::new(rustls::crypto::ring::default_provider())))
+        Arc::new(Self)
     }
 }
 
 impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
     fn verify_tls12_signature(
         &self,
-        message: &[u8],
-        cert: &rustls::pki_types::CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls12_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
+        Err(rustls::Error::PeerIncompatible(
+            rustls::PeerIncompatible::Tls13RequiredForQuic,
+        ))
     }
 
     fn verify_tls13_signature(
@@ -58,16 +57,11 @@ impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
         cert: &rustls::pki_types::CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls13_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
+        rustls::crypto::verify_tls13_signature(message, cert, dss, &TLS_SIGVERIFY_SCHEMES)
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        self.0.signature_verification_algorithms.supported_schemes()
+        TLS_SIGVERIFY_SCHEMES.supported_schemes()
     }
 
     fn verify_server_cert(


### PR DESCRIPTION
#### Problem

A malicious peer may cause Agave to waste time verifying RSA-4096 certs.

#### Summary of Changes

- Ban use of other TLS signature algorithms such as RSA
- Add boilerplate to replace ring's Ed25519 verifier with Dalek

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
